### PR TITLE
fix ci status error for un-open pull requests

### DIFF
--- a/gradle/changelog/fix_ci_status_error_for_un-open_pull_requests.yaml
+++ b/gradle/changelog/fix_ci_status_error_for_un-open_pull_requests.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Ci status error for un-open pull requests ([#40](https://github.com/scm-manager/scm-ci-plugin/pull/40))

--- a/gradle/changelog/fix_ci_status_error_for_un-open_pull_requests.yaml
+++ b/gradle/changelog/fix_ci_status_error_for_un-open_pull_requests.yaml
@@ -1,2 +1,2 @@
 - type: fixed
-  description: Ci status error for un-open pull requests ([#40](https://github.com/scm-manager/scm-ci-plugin/pull/40))
+  description: CI status error for closed pull requests ([#40](https://github.com/scm-manager/scm-ci-plugin/pull/40))

--- a/src/main/js/CIStatus.ts
+++ b/src/main/js/CIStatus.ts
@@ -24,31 +24,6 @@
 
 import { apiClient } from "@scm-manager/ui-components";
 import { Branch, Link, Repository } from "@scm-manager/ui-types";
-
-/*
- * MIT License
- *
- * Copyright (c) 2020-present Cloudogu GmbH and Contributors
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
-
 import { useQuery } from "react-query";
 
 export type CIStatus = {
@@ -71,6 +46,13 @@ export const useCiStatus = (
   context: CiStatusContext,
   callback: (ciStatus: CIStatus[]) => void
 ) => {
+  let url: string | undefined;
+  if (context.pullRequest) {
+    url = (context.pullRequest._links.ciStatus as Link)?.href;
+  } else if (context.branch) {
+    url = (context.branch._links.details as Link)?.href;
+  }
+
   const { error, isLoading, data } = useQuery<CIStatus[], Error>(
     [
       "repository",
@@ -80,27 +62,17 @@ export const useCiStatus = (
       context.pullRequest ? "pull-request" : "branch",
       context.pullRequest?.id || context.branch?.name
     ],
-    () => {
-      if (context.pullRequest) {
-        return apiClient
-          .get((context.pullRequest._links.ciStatus as Link)?.href)
-          .then(response => response.json())
-          .then(json => json._embedded.ciStatus)
-          .then(ciStatus => {
-            callback(ciStatus);
-            return ciStatus;
-          });
-      } else if (context.branch) {
-        return apiClient
-          .get((context.branch._links.details as Link)?.href)
-          .then(response => response.json())
-          .then(json => json._embedded.ciStatus)
-          .then(ciStatus => {
-            callback(ciStatus);
-            return ciStatus;
-          });
-      }
-      return [];
+    () =>
+      apiClient
+        .get(url!)
+        .then(response => response.json())
+        .then(json => json._embedded.ciStatus)
+        .then(ciStatus => {
+          callback(ciStatus);
+          return ciStatus;
+        }),
+    {
+      enabled: !!url
     }
   );
 

--- a/src/main/js/CIStatusBar.tsx
+++ b/src/main/js/CIStatusBar.tsx
@@ -47,8 +47,11 @@ const CIStatusBar: FC<Props> = ({ repository, pullRequest, branch }) => {
   if (error) {
     return <ErrorNotification error={error} />;
   }
-  if (isLoading || !ciStatus) {
+  if (isLoading) {
     return <Loading />;
+  }
+  if (!ciStatus) {
+    return null;
   }
 
   const success = ciStatus?.every((ci: CIStatus) => ci.status === "SUCCESS");


### PR DESCRIPTION
## Proposed changes

The recent transition to react-query caused un-open PRs to display an error. This PR makes sure that the ciStatus is only fetched if a url is present, otherwise no ci status is displayed at all.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
