### PR TITLE
Fix NPE for unknown revision

### DIFF
--- a/gradle/changelog/npe.yaml
+++ b/gradle/changelog/npe.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: NullPointerException thrown for unknown revision ([#43](https://github.com/scm-manager/scm-ci-plugin/pull/43))

--- a/src/test/java/com/cloudogu/scm/ci/cistatus/api/ChangesetCIStatusRootResourceTest.java
+++ b/src/test/java/com/cloudogu/scm/ci/cistatus/api/ChangesetCIStatusRootResourceTest.java
@@ -25,11 +25,13 @@ package com.cloudogu.scm.ci.cistatus.api;
 
 import com.cloudogu.scm.ci.RepositoryResolver;
 import com.cloudogu.scm.ci.cistatus.service.CIStatusService;
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.NotFoundException;
 import sonia.scm.repository.Changeset;
 import sonia.scm.repository.Repository;
 import sonia.scm.repository.RepositoryTestData;
@@ -81,5 +83,16 @@ class ChangesetCIStatusRootResourceTest {
 
     assertThat(resource.getRepository()).isSameAs(repository);
     assertThat(resource.getChangesetId()).isEqualTo("42");
+  }
+
+  @Test
+  void shouldFailForUnknownRevision() throws IOException {
+    Repository repository = RepositoryTestData.createHeartOfGold();
+    when(resolver.resolve("hitchhiker", "heart-of-gold")).thenReturn(repository);
+    when(repositoryServiceFactory.create(any(Repository.class))).thenReturn(repositoryService);
+    when(repositoryService.getLogCommand()).thenReturn(logCommandBuilder);
+    when(logCommandBuilder.getChangeset("42")).thenReturn(null);
+
+    Assert.assertThrows(NotFoundException.class, () -> rootResource.getChangesetCIStatusResource("hitchhiker", "heart-of-gold", "42"));
   }
 }


### PR DESCRIPTION
## Proposed changes

Fixes a NullPointerException that is thrown when the revision in a CI status PUT request is given completely, but does not exist. This exception will not be thrown in Git repositories for shortened revisions, because in this case another NullPointerException is catched in the Git plugin and will be converted into a NotFoundException there.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [x] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [x] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
