### PR TITLE
Do not fail with old configuration

### DIFF
--- a/gradle/changelog/npe.yaml
+++ b/gradle/changelog/npe.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Do not fail with old configuration ([#53](https://github.com/scm-manager/scm-ci-plugin/pull/53))

--- a/src/main/java/com/cloudogu/scm/ci/cistatus/workflow/CIStatusAllSuccessRule.java
+++ b/src/main/java/com/cloudogu/scm/ci/cistatus/workflow/CIStatusAllSuccessRule.java
@@ -56,7 +56,8 @@ public class CIStatusAllSuccessRule implements Rule {
   @Override
   public Result validate(Context context) {
     Configuration configuration = context.getConfiguration(Configuration.class);
-    CIStatusCollection ciStatuses = statusResolver.resolve(context, configuration.isIgnoreChangesetStatus());
+    boolean ignoreChangesetStatus = configuration != null && configuration.isIgnoreChangesetStatus();
+    CIStatusCollection ciStatuses = statusResolver.resolve(context, ignoreChangesetStatus);
     for (CIStatus status : ciStatuses) {
       if (status.getStatus() != Status.SUCCESS) {
         return failed();

--- a/src/test/java/com/cloudogu/scm/ci/cistatus/workflow/CIStatusAllSuccessRuleTest.java
+++ b/src/test/java/com/cloudogu/scm/ci/cistatus/workflow/CIStatusAllSuccessRuleTest.java
@@ -116,6 +116,19 @@ class CIStatusAllSuccessRuleTest {
     assertThat(result.isSuccess()).isTrue();
   }
 
+  @Test
+  void shouldNotFailWithMissingConfiguration() {
+    when(context.getConfiguration(CIStatusAllSuccessRule.Configuration.class))
+      .thenReturn(null);
+    CIStatusCollection collection = new CIStatusCollection();
+    collection.put(createStatus(Status.SUCCESS));
+    when(statusResolver.resolve(context, false)).thenReturn(collection);
+
+    Result result = rule.validate(context);
+
+    assertThat(result.isSuccess()).isTrue();
+  }
+
   private CIStatus createStatus(Status status) {
     return new CIStatus("jenkins", "spaceship", "Spaceship", status, "http://hitchhiker.com");
   }


### PR DESCRIPTION
## Proposed changes

When there are configurations with the "all status rule" that
were configured before the "ignore changesets" option has been
added, this rule has no configuration (aka null). Therefore, we
get a NullPointerException, when this rule is evaluated.

To avoid this, we add a check if we have a configuration.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
