### PR TITLE
Fix loading spinner in pull request table

### DIFF
--- a/gradle/changelog/loading_spinner.yaml
+++ b/gradle/changelog/loading_spinner.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Loading spinner for ci status for closed pull requests in pull request table ([#59](https://github.com/scm-manager/scm-ci-plugin/pull/59))

--- a/src/main/js/RepositoryTableColumnExtension.tsx
+++ b/src/main/js/RepositoryTableColumnExtension.tsx
@@ -29,6 +29,9 @@ import { useCiStatus } from "./CIStatus";
 
 const CiStatusWrapper = ({ repository, pullRequest }) => {
   const { data } = useCiStatus(repository, { pullRequest });
+  if (!pullRequest._links.ciStatus) {
+    return null;
+  }
   return <CIStatusSummary explicitCiStatus={data} repository={repository} />;
 };
 


### PR DESCRIPTION
For merged and rejected pull requests we have no ci status and therefore no link for it. This lead to a loading spinner in the pull request table nonetheless, which is fixed with this commit.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Please ensure the "what" and "why" are explained properly in this description as it will be used as the commit description on squashing your pull request commits. 

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [ ] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
